### PR TITLE
align with .net impl, support many:one service-to-device app ratios

### DIFF
--- a/python/common/system_health_telemetry.py
+++ b/python/common/system_health_telemetry.py
@@ -1,0 +1,41 @@
+# Copyright (c) Microsoft. All rights reserved.
+# Licensed under the MIT license. See LICENSE file in the project root for
+# full license information.
+import platform
+import os
+import psutil
+
+
+class SystemHealthTelemetry(object):
+    def __init__(self):
+        self.process = psutil.Process(os.getpid())
+        self.system = platform.system()
+
+    @property
+    def process_cpu_percent(self):
+        return self.process.cpu_percent()
+
+    @property
+    def process_working_set(self):
+        return self.process.memory_info().rss
+
+    @property
+    def process_bytes_in_all_heaps(self):
+        return self.process.memory_info().vms
+
+    @property
+    def process_private_bytes(self):
+        if self.system == "Linux":
+            memory_info = self.process.memory_info()
+            # from /proc/{pid}/statm - equal to (VmRSS - (RssFile+RssShmem)) from /proc/{pid}/status
+            return memory_info.rss - memory_info.shared
+        elif self.system == "Windows":
+            # from SYSTEM_PROCESS_INFORMATION.PrivatePageCount
+            return self.memory_info().pivate
+        else:
+            # osx, aix, bsd -- undefined
+            return 0
+
+    @property
+    def process_working_set_private(self):
+        return self.process_private_bytes

--- a/scripts/fetch-secrets.sh
+++ b/scripts/fetch-secrets.sh
@@ -18,8 +18,20 @@ function get-secret {
     export ${bash_name}=${value}
 }
 
+# This script is intended for developer workstations.  When these tests runs in the cloud,
+# they use a different mechanism to get secrets.
+#
+# Since this is a developer workstation, set the device ID and run IDs so the developer runs
+# all communicate with each other instead of accidentally pairing with service apps that are
+# running in the cloud.
 echo "Setting THIEF_DEVICE_ID"
 export THIEF_DEVICE_ID=${USER}_test_device
+echo "Setting THIEF_DEVICE_APP_RUN_ID"
+export THIEF_DEVICE_APP_RUN_ID=${USER}_device_app_run_id
+echo "Setting THIEF_SERVICE_APP_RUN_ID"
+export THIEF_SERVICE_APP_RUN_ID=${USER}_service_app_run_id
+echo "setting THIEF_REQUESTED_SERVICE_APP_RUN_ID"
+export THIEF_REQUESTED_SERVICE_APP_RUN_ID=${THIEF_SERVICE_APP_RUN_ID}
 
 get-secret THIEF_SERVICE_CONNECTION_STRING THIEF-SERVICE-CONNECTION-STRING
 get-secret THIEF_DEVICE_PROVISIONING_HOST THIEF-DEVICE-PROVISIONING-HOST


### PR DESCRIPTION
* Aligned telemetry names with .net
* refactored system_health_telemetry.py to match .net
* removed heartbeat.  we decided that this was too extreme and a different mechanism to deal with missing partners will be added later.
* changed code so we can have a single service app that works with multiple device apps.
* added "bootstrap" mechanism that a device can use to pair itself with a service app.
* added environmental variables for run_id and a way for a device app to pair with a specific service app.