### PR TITLE
handle and log duplicate service acks

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -68,6 +68,7 @@ Most or all of the test metrics overlap with metrics that are sent in telemetry 
           "reportedPropertiesCountRemoved": 0,
           "reportedPropertiesCountRemovedButNotVerifiedByServiceApp": 0,
           "sendMessageCountExceptions": 0,
+          "sendMessageCountExtraServiceAcksReceived": 0,
           "sendMessageCountInBacklog": 0,
           "sendMessageCountNotReceivedByServiceApp": 0,
           "sendMessageCountSent": 0,
@@ -91,6 +92,7 @@ Most or all of the test metrics overlap with metrics that are sent in telemetry 
 | `sendMessageCountExceptions` | integer | Count of test telemetry operations which failed.  Failures could be caused by raised exceptions or by messages withoug a matching `serviceAck`. |
 | `sendMessageCountInBacklog` | integer | Count of test telemetry messages currently queued in the  acklock.  Queued messages are scheduled to be sent, but not yet in transit. Not all test implementations queue in the client, so this metric may be meaningless in cases where queueing happens inside the SDK. |
 | `sendMessageCountNotReceivedByServiceApp` | integer | Count of test telemetry messages which were sent, ack'ed by the transport (`PUBACK`), but not received by the service (no `serviceAck`) |
+| `sendMessageCountExtraServiceAcksReceived` | integer | Count of service acks received that aren't being waited for.  Probably caused by duplicate c2d messages because of QOS 1 |
 
 ## System Health Metrics
 

--- a/python/common/thief_constants.py
+++ b/python/common/thief_constants.py
@@ -174,6 +174,8 @@ class MetricNames(object):
     SEND_MESSAGE_COUNT_UNACKED = "sendMessageCountUnacked"
     # Number of telemetry messages that have not (yet) arrived at the hub
     SEND_MESSAGE_COUNT_NOT_RECEIVED = "sendMessageCountNotReceivedByServiceApp"
+    # Number of "extra" service acks received -- probably duplicte messages
+    SEND_MESSAGE_COUNT_EXTRA_SERVICE_ACKS_RECEIVED = "sendMessageCountExtraServiceAcksReceived"
 
     # -------------------
     # Receive c2d metrics


### PR DESCRIPTION
My python app was crashing when it received a service ack that it wasn't waiting for.  I assume we were getting duplicate messages (possible and valid with MQTT QOS 1).  This code fixes the crash and logs and counts how many times this happens.