### PR TITLE
Add runReason and exitReason to startingRun and endingRun events

### DIFF
--- a/docs/azure-monitor-custom-dimensions.md
+++ b/docs/azure-monitor-custom-dimensions.md
@@ -65,15 +65,6 @@ Other service app logs are not device specific and do not contain `deviceId` and
 | `runReason` | string | Reason the test is running.  Free-form string added to `StartingRun` events to explain why the run is happening.  |
 | `exitReason` | string | Reason the test is exiting.  Free-form string added to `EndingRun` events to explain why the run stopped. |
 
-## Fields used for tracking Events
-
-Some custom dimensions are used for correlating events, such as being able to associate a SendTelemetry event with it's corresponding ReceiveTelemetry event.
-
-| field | format | meaning |
-| - | - | - |
-| `serviceAckId` | guid |  ServiceAckId associated with a telemetry message. Attached to all events associated with the message. |
-| `c2dIndex` | integer | `testC2dMessageIndex` value associated with a c2d message.  Attached to all events assicated with the message. |
-| `reportedPropertyName` | string | Name of a reported property that is being set or cleared for testing.  Attached to all events associated with the property. |
 
 ## Metric names
 

--- a/docs/azure-monitor-custom-dimensions.md
+++ b/docs/azure-monitor-custom-dimensions.md
@@ -50,8 +50,6 @@ Other service app logs are not device specific and do not contain `deviceId` and
   {
     "lineNumber": "291",
     "fileName": "service.py",
-    "level": "INFO",
-    "module": "service",
   }
 ```
 
@@ -59,8 +57,23 @@ Other service app logs are not device specific and do not contain `deviceId` and
 | - | - | - |
 | `level` | string | debug level for generated message |
 | `module`| string | module generating message (without path and extension) |
-| `lineNumber` | integer | line number in source file which is generating this message |
-| `fileName` | string | filename generating message (with path and extension) |
+
+## Fields for recording run details
+
+| field | format | meaning |
+| - | - | - |
+| `runReason` | string | Reason the test is running.  Free-form string added to `StartingRun` events to explain why the run is happening.  |
+| `exitReason` | string | Reason the test is exiting.  Free-form string added to `EndingRun` events to explain why the run stopped. |
+
+## Fields used for tracking Events
+
+Some custom dimensions are used for correlating events, such as being able to associate a SendTelemetry event with it's corresponding ReceiveTelemetry event.
+
+| field | format | meaning |
+| - | - | - |
+| `serviceAckId` | guid |  ServiceAckId associated with a telemetry message. Attached to all events associated with the message. |
+| `c2dIndex` | integer | `testC2dMessageIndex` value associated with a c2d message.  Attached to all events assicated with the message. |
+| `reportedPropertyName` | string | Name of a reported property that is being set or cleared for testing.  Attached to all events associated with the property. |
 
 ## Metric names
 

--- a/docs/azure-monitor-events.md
+++ b/docs/azure-monitor-events.md
@@ -12,30 +12,3 @@ The following Azure Monitor custom events can be fired by the device app:
 | ReceivedPairingResponse | Device app received desired properties with pairing values |
 | PairingComplete | Device app is successfully paired with service app |
 
-## Operation tracking
-
-The following Azure Monitor custom events can be fired by the device app or the service app.
-They are used to record when and how often various events happen.
-Because the events are timestamped, they can be used to record latency between various events.
-
-### Telemetry
-| Event Name | Meaning |
-| - | - | 
-| `SendTelemetry` | A test telemetry message is being sent by the device app. |
-| `ReceiveTelemetry` | A test telemetry message has been received by the service app. |
-| `ReceiveServiceAck` | The device app has received a serviceAck. |
-
-### Send C2D
-| Event Name | Meaning |
-| - | - | 
-| `SendC2d` | The service app is sending a test c2d message. |
-| `ReceiveC2d` | The device app has received a test c2d message. |
-
-### Reported Properties
-| Event Name | Meaning |
-| - | - | 
-| `AddReportedProperty` | The device app has added a reported property. |
-| `RemoveReportedProperty` | The device app has removed a reported property. |
-| `ObserveReportedPropertyAdd` | The service property has observed a reported property being added. |
-| `ObserveReportedPropertyRemove` | The service property has observed a reported property being removed. |
-

--- a/docs/azure-monitor-events.md
+++ b/docs/azure-monitor-events.md
@@ -12,3 +12,30 @@ The following Azure Monitor custom events can be fired by the device app:
 | ReceivedPairingResponse | Device app received desired properties with pairing values |
 | PairingComplete | Device app is successfully paired with service app |
 
+## Operation tracking
+
+The following Azure Monitor custom events can be fired by the device app or the service app.
+They are used to record when and how often various events happen.
+Because the events are timestamped, they can be used to record latency between various events.
+
+### Telemetry
+| Event Name | Meaning |
+| - | - | 
+| `SendTelemetry` | A test telemetry message is being sent by the device app. |
+| `ReceiveTelemetry` | A test telemetry message has been received by the service app. |
+| `ReceiveServiceAck` | The device app has received a serviceAck. |
+
+### Send C2D
+| Event Name | Meaning |
+| - | - | 
+| `SendC2d` | The service app is sending a test c2d message. |
+| `ReceiveC2d` | The device app has received a test c2d message. |
+
+### Reported Properties
+| Event Name | Meaning |
+| - | - | 
+| `AddReportedProperty` | The device app has added a reported property. |
+| `RemoveReportedProperty` | The device app has removed a reported property. |
+| `ObserveReportedPropertyAdd` | The service property has observed a reported property being added. |
+| `ObserveReportedPropertyRemove` | The service property has observed a reported property being removed. |
+

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -68,7 +68,6 @@ Most or all of the test metrics overlap with metrics that are sent in telemetry 
           "reportedPropertiesCountRemoved": 0,
           "reportedPropertiesCountRemovedButNotVerifiedByServiceApp": 0,
           "sendMessageCountExceptions": 0,
-          "sendMessageCountExtraServiceAcksReceived": 0,
           "sendMessageCountInBacklog": 0,
           "sendMessageCountNotReceivedByServiceApp": 0,
           "sendMessageCountSent": 0,
@@ -92,7 +91,6 @@ Most or all of the test metrics overlap with metrics that are sent in telemetry 
 | `sendMessageCountExceptions` | integer | Count of test telemetry operations which failed.  Failures could be caused by raised exceptions or by messages withoug a matching `serviceAck`. |
 | `sendMessageCountInBacklog` | integer | Count of test telemetry messages currently queued in the  acklock.  Queued messages are scheduled to be sent, but not yet in transit. Not all test implementations queue in the client, so this metric may be meaningless in cases where queueing happens inside the SDK. |
 | `sendMessageCountNotReceivedByServiceApp` | integer | Count of test telemetry messages which were sent, ack'ed by the transport (`PUBACK`), but not received by the service (no `serviceAck`) |
-| `sendMessageCountExtraServiceAcksReceived` | integer | Count of service acks received that aren't being waited for.  Probably caused by duplicate c2d messages because of QOS 1 |
 
 ## System Health Metrics
 

--- a/python/common/thief_constants.py
+++ b/python/common/thief_constants.py
@@ -179,8 +179,6 @@ class MetricNames(object):
     SEND_MESSAGE_COUNT_UNACKED = "sendMessageCountUnacked"
     # Number of telemetry messages that have not (yet) arrived at the hub
     SEND_MESSAGE_COUNT_NOT_RECEIVED = "sendMessageCountNotReceivedByServiceApp"
-    # Number of "extra" service acks received -- probably duplicte messages
-    SEND_MESSAGE_COUNT_EXTRA_SERVICE_ACKS_RECEIVED = "sendMessageCountExtraServiceAcksReceived"
 
     # -------------------
     # Receive c2d metrics

--- a/python/common/thief_constants.py
+++ b/python/common/thief_constants.py
@@ -139,27 +139,6 @@ class Events(object):
     # The pairing process is complete.
     PAIRING_COMPLETE = "PairingComplete"
 
-    # A test telemetry message is being sent by the device app
-    SEND_TELEMETRY = "SendTelemetry"
-    # A test telemetry message has been received by the service app
-    RECEIVE_TELEMETRY = "ReceiveTelemetry"
-    # The device app has received a serviceAck
-    RECEIVE_SERVICE_ACK = "ReceiveServiceAck"
-
-    # The service app is sending a test c2d message
-    SEND_C2D = "SendC2d"
-    # The device app has received a test c2d message
-    RECEIVE_C2D = "ReceiveC2d"
-
-    # The device app has added a reported property
-    ADD_REPORTED_PROPERTY = "AddReportedProperty"
-    # The device app has removed a reported property
-    REMOVE_REPORTED_PROPERTY = "RemoveReportedProperty"
-    # The service property has observed a reported property being added
-    OBSERVE_REPORTED_PROPERTY_ADD = "ObserveReportedPropertyAdd"
-    # The service property has observed a reported property being removed
-    OBSERVE_REPORTED_PROPERTY_REMOVE = "ObserveReportedPropertyRemove"
-
 
 class MetricNames(object):
     """
@@ -316,10 +295,3 @@ class CustomDimensionNames(object):
     RUN_REASON = "runReason"
     # Reason the test is exiting
     EXIT_REASON = "exitReason"
-
-    # ServiceAckId associated with the message
-    SERVICE_ACK_ID = "serviceAckId"
-    # testC2dMessageIndex associated with the message
-    C2D_INDEX = "c2dIndex"
-    # reported property name associated with the message
-    REPORTED_PROPERTY_NAME = "reportedPropertyName"

--- a/python/common/thief_constants.py
+++ b/python/common/thief_constants.py
@@ -128,11 +128,37 @@ class Events(object):
     Names of different Azure Monitor events
     """
 
+    # The test run is starting
     STARTING_RUN = "StartingRun"
+    # The test run is ending
     ENDING_RUN = "EndingRun"
+    # The device app is sending a pairing request to the service app
     SENDING_PAIRING_REQUEST = "SendingPairingRequest"
+    # The device app has received a pairing response from the service app
     RECEIVED_PAIRING_RESPONSE = "ReceivedPairingResponse"
+    # The pairing process is complete.
     PAIRING_COMPLETE = "PairingComplete"
+
+    # A test telemetry message is being sent by the device app
+    SEND_TELEMETRY = "SendTelemetry"
+    # A test telemetry message has been received by the service app
+    RECEIVE_TELEMETRY = "ReceiveTelemetry"
+    # The device app has received a serviceAck
+    RECEIVE_SERVICE_ACK = "ReceiveServiceAck"
+
+    # The service app is sending a test c2d message
+    SEND_C2D = "SendC2d"
+    # The device app has received a test c2d message
+    RECEIVE_C2D = "ReceiveC2d"
+
+    # The device app has added a reported property
+    ADD_REPORTED_PROPERTY = "AddReportedProperty"
+    # The device app has removed a reported property
+    REMOVE_REPORTED_PROPERTY = "RemoveReportedProperty"
+    # The service property has observed a reported property being added
+    OBSERVE_REPORTED_PROPERTY_ADD = "ObserveReportedPropertyAdd"
+    # The service property has observed a reported property being removed
+    OBSERVE_REPORTED_PROPERTY_REMOVE = "ObserveReportedPropertyRemove"
 
 
 class MetricNames(object):
@@ -263,15 +289,37 @@ class CustomDimensionNames(object):
     Names of customDimension fields pushed to Azure Monitor
     """
 
+    # OS type, e.g. Linux, Windows
     OS_TYPE = "osType"
+    # Langauge being used.  e.g. Python, Node, dotnet
     SDK_LANGUAGE = "sdkLanguage"
+    # Version of language being used.  e.g. 3.8.1
     SDK_LANGUAGE_VERSION = "sdkLanguageVersion"
+    # Version of the SDK library being tested.  e.g. 2.4.2
     SDK_VERSION = "sdkVersion"
 
+    # ServiceInstanceId being used for this test run
     SERVICE_INSTANCE_ID = "serviceInstanceId"
+    # RunId for the run.  May be None for service app features that aren't tied to a specific run
     RUN_ID = "runId"
+    # Service app pool being used
     POOL_ID = "poolId"
 
+    # Hub instance being used, without the .azuredevices.net suffix
     HUB = "hub"
+    # Device being tested
     DEVICE_ID = "deviceId"
+    # Transport being used by the device under test
     TRANSPORT = "transport"
+
+    # Reason the test is running
+    RUN_REASON = "runReason"
+    # Reason the test is exiting
+    EXIT_REASON = "exitReason"
+
+    # ServiceAckId associated with the message
+    SERVICE_ACK_ID = "serviceAckId"
+    # testC2dMessageIndex associated with the message
+    C2D_INDEX = "c2dIndex"
+    # reported property name associated with the message
+    REPORTED_PROPERTY_NAME = "reportedPropertyName"

--- a/python/device/device.py
+++ b/python/device/device.py
@@ -63,7 +63,6 @@ azure_monitor.add_logging_properties(
     pool_id=requested_service_pool,
 )
 event_logger = azure_monitor.get_event_logger()
-azure_monitor.log_all_warnings_and_exceptions_to_azure_monitor()
 azure_monitor.log_to_azure_monitor("thief")
 
 
@@ -112,7 +111,6 @@ class DeviceRunMetrics(object):
         self.send_message_count_unacked = ThreadSafeCounter()
         self.send_message_count_sent = ThreadSafeCounter()
         self.send_message_count_received_by_service_app = ThreadSafeCounter()
-        self.send_message_count_extra_service_acks_received = ThreadSafeCounter()
 
         self.receive_c2d_count_received = ThreadSafeCounter()
 
@@ -235,11 +233,6 @@ class DeviceApp(app_base.AppBase):
             "Count of messages sent to iothub and acked by the transport, but receipt not (yet) verified via service sdk",
             "message(s)",
         )
-        self.reporter.add_integer_measurement(
-            MetricNames.SEND_MESSAGE_COUNT_EXTRA_SERVICE_ACKS_RECEIVED,
-            "Number of 'extra' service acks received -- probably duplicte messages",
-            "message(s)",
-        )
 
         # -------------------
         # Receive c2d metrics
@@ -339,7 +332,6 @@ class DeviceApp(app_base.AppBase):
             MetricNames.SEND_MESSAGE_COUNT_IN_BACKLOG: self.outgoing_test_message_queue.qsize(),
             MetricNames.SEND_MESSAGE_COUNT_UNACKED: self.metrics.send_message_count_unacked.get_count(),
             MetricNames.SEND_MESSAGE_COUNT_NOT_RECEIVED: sent - received_by_service_app,
-            MetricNames.SEND_MESSAGE_COUNT_EXTRA_SERVICE_ACKS_RECEIVED: self.metrics.send_message_count_extra_service_acks_received.get_count(),
             MetricNames.RECEIVE_C2D_COUNT_RECEIVED: self.metrics.receive_c2d_count_received.get_count(),
             MetricNames.RECEIVE_C2D_COUNT_MISSING: self.out_of_order_message_tracker.get_missing_count(),
             MetricNames.REPORTED_PROPERTIES_COUNT_ADDED: self.metrics.reported_properties_count_added.get_count(),
@@ -664,31 +656,20 @@ class DeviceApp(app_base.AppBase):
                     self.metrics.send_message_count_received_by_service_app.increment()
 
                     with self.service_ack_list_lock:
-                        wait_info = self.service_ack_wait_list.get(service_ack_id, None)
+                        wait_info = self.service_ack_wait_list[service_ack_id]
 
-                    if wait_info:
-                        with self.reporter_lock:
-                            self.reporter.set_metrics_from_dict(
-                                {
-                                    MetricNames.LATENCY_QUEUE_MESSAGE_TO_SEND: (
-                                        wait_info.send_epochtime - wait_info.queue_epochtime
-                                    )
-                                    * 1000,
-                                    MetricNames.LATENCY_SEND_MESSAGE_TO_SERVICE_ACK: time.time()
-                                    - wait_info.send_epochtime,
-                                }
-                            )
-                            self.reporter.record()
-                    else:
-                        # If we don't have a wait_info struct for this service_ack_id, we assume that
-                        # The MQTT "at least once" part of QOS-1 means that we received the ack
-                        # once before and now we're receiving it again.
-                        self.metrics.send_message_count_extra_service_acks_received.increment()
-                        logger.info(
-                            "Received extra serviceAck with serviceAckId = {}".format(
-                                service_ack_id
-                            )
+                    with self.reporter_lock:
+                        self.reporter.set_metrics_from_dict(
+                            {
+                                MetricNames.LATENCY_QUEUE_MESSAGE_TO_SEND: (
+                                    wait_info.send_epochtime - wait_info.queue_epochtime
+                                )
+                                * 1000,
+                                MetricNames.LATENCY_SEND_MESSAGE_TO_SERVICE_ACK: time.time()
+                                - wait_info.send_epochtime,
+                            }
                         )
+                        self.reporter.record()
 
                 # This function only queues the message.  A send_message_thread instance will pick
                 # it up and send it.

--- a/python/service/service.py
+++ b/python/service/service.py
@@ -47,7 +47,6 @@ azure_monitor.add_logging_properties(
     pool_id=service_pool,
 )
 event_logger = azure_monitor.get_event_logger()
-azure_monitor.log_all_warnings_and_exceptions_to_azure_monitor()
 azure_monitor.log_to_azure_monitor("thief")
 
 ServiceAck = collections.namedtuple("ServiceAck", "device_id service_ack_id")
@@ -365,7 +364,10 @@ class ServiceApp(app_base.AppBase):
                     break
                 if service_ack.device_id not in service_acks:
                     service_acks[service_ack.device_id] = []
-                service_acks[service_ack.device_id].append(service_ack.service_ack_id)
+                # it's possible to get the same eventhub message twice, especially if we have to reconnect
+                # to refresh credentials. Don't send the same service ack twice.
+                if service_ack.service_ack_id not in service_acks[service_ack.device_id]:
+                    service_acks[service_ack.device_id].append(service_ack.service_ack_id)
 
             for device_id in service_acks:
 


### PR DESCRIPTION
I'm trying something new.  I'm firing events for different operations (like sending telemetry) and using a guid in the customDimensions to relate that to other events (like receiving telemetry).  The kusto join is fairly simple and gives us some better metrics.