### PR TITLE
Don't log error and warning messages twice

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -68,7 +68,6 @@ Most or all of the test metrics overlap with metrics that are sent in telemetry 
           "reportedPropertiesCountRemoved": 0,
           "reportedPropertiesCountRemovedButNotVerifiedByServiceApp": 0,
           "sendMessageCountExceptions": 0,
-          "sendMessageCountExtraServiceAcksReceived": 0,
           "sendMessageCountInBacklog": 0,
           "sendMessageCountNotReceivedByServiceApp": 0,
           "sendMessageCountSent": 0,
@@ -92,7 +91,6 @@ Most or all of the test metrics overlap with metrics that are sent in telemetry 
 | `sendMessageCountExceptions` | integer | Count of test telemetry operations which failed.  Failures could be caused by raised exceptions or by messages withoug a matching `serviceAck`. |
 | `sendMessageCountInBacklog` | integer | Count of test telemetry messages currently queued in the  acklock.  Queued messages are scheduled to be sent, but not yet in transit. Not all test implementations queue in the client, so this metric may be meaningless in cases where queueing happens inside the SDK. |
 | `sendMessageCountNotReceivedByServiceApp` | integer | Count of test telemetry messages which were sent, ack'ed by the transport (`PUBACK`), but not received by the service (no `serviceAck`) |
-| `sendMessageCountExtraServiceAcksReceived` | integer | Count of service acks received that aren't being waited for.  Probably caused by duplicate c2d messages because of QOS 1 |
 
 ## System Health Metrics
 

--- a/python/common/thief_constants.py
+++ b/python/common/thief_constants.py
@@ -200,8 +200,6 @@ class MetricNames(object):
     SEND_MESSAGE_COUNT_UNACKED = "sendMessageCountUnacked"
     # Number of telemetry messages that have not (yet) arrived at the hub
     SEND_MESSAGE_COUNT_NOT_RECEIVED = "sendMessageCountNotReceivedByServiceApp"
-    # Number of "extra" service acks received -- probably duplicte messages
-    SEND_MESSAGE_COUNT_EXTRA_SERVICE_ACKS_RECEIVED = "sendMessageCountExtraServiceAcksReceived"
 
     # -------------------
     # Receive c2d metrics

--- a/python/device/device.py
+++ b/python/device/device.py
@@ -111,7 +111,6 @@ class DeviceRunMetrics(object):
         self.send_message_count_unacked = ThreadSafeCounter()
         self.send_message_count_sent = ThreadSafeCounter()
         self.send_message_count_received_by_service_app = ThreadSafeCounter()
-        self.send_message_count_extra_service_acks_received = ThreadSafeCounter()
 
         self.receive_c2d_count_received = ThreadSafeCounter()
 
@@ -234,11 +233,6 @@ class DeviceApp(app_base.AppBase):
             "Count of messages sent to iothub and acked by the transport, but receipt not (yet) verified via service sdk",
             "message(s)",
         )
-        self.reporter.add_integer_measurement(
-            MetricNames.SEND_MESSAGE_COUNT_EXTRA_SERVICE_ACKS_RECEIVED,
-            "Number of 'extra' service acks received -- probably duplicte messages",
-            "message(s)",
-        )
 
         # -------------------
         # Receive c2d metrics
@@ -338,7 +332,6 @@ class DeviceApp(app_base.AppBase):
             MetricNames.SEND_MESSAGE_COUNT_IN_BACKLOG: self.outgoing_test_message_queue.qsize(),
             MetricNames.SEND_MESSAGE_COUNT_UNACKED: self.metrics.send_message_count_unacked.get_count(),
             MetricNames.SEND_MESSAGE_COUNT_NOT_RECEIVED: sent - received_by_service_app,
-            MetricNames.SEND_MESSAGE_COUNT_EXTRA_SERVICE_ACKS_RECEIVED: self.metrics.send_message_count_extra_service_acks_received.get_count(),
             MetricNames.RECEIVE_C2D_COUNT_RECEIVED: self.metrics.receive_c2d_count_received.get_count(),
             MetricNames.RECEIVE_C2D_COUNT_MISSING: self.out_of_order_message_tracker.get_missing_count(),
             MetricNames.REPORTED_PROPERTIES_COUNT_ADDED: self.metrics.reported_properties_count_added.get_count(),
@@ -673,31 +666,20 @@ class DeviceApp(app_base.AppBase):
                     )
 
                     with self.service_ack_list_lock:
-                        wait_info = self.service_ack_wait_list.get(service_ack_id, None)
+                        wait_info = self.service_ack_wait_list[service_ack_id]
 
-                    if wait_info:
-                        with self.reporter_lock:
-                            self.reporter.set_metrics_from_dict(
-                                {
-                                    MetricNames.LATENCY_QUEUE_MESSAGE_TO_SEND: (
-                                        wait_info.send_epochtime - wait_info.queue_epochtime
-                                    )
-                                    * 1000,
-                                    MetricNames.LATENCY_SEND_MESSAGE_TO_SERVICE_ACK: time.time()
-                                    - wait_info.send_epochtime,
-                                }
-                            )
-                            self.reporter.record()
-                    else:
-                        # If we don't have a wait_info struct for this service_ack_id, we assume that
-                        # The MQTT "at least once" part of QOS-1 means that we received the ack
-                        # once before and now we're receiving it again.
-                        self.metrics.send_message_count_extra_service_acks_received.increment()
-                        logger.info(
-                            "Received extra serviceAck with serviceAckId = {}".format(
-                                service_ack_id
-                            )
+                    with self.reporter_lock:
+                        self.reporter.set_metrics_from_dict(
+                            {
+                                MetricNames.LATENCY_QUEUE_MESSAGE_TO_SEND: (
+                                    wait_info.send_epochtime - wait_info.queue_epochtime
+                                )
+                                * 1000,
+                                MetricNames.LATENCY_SEND_MESSAGE_TO_SERVICE_ACK: time.time()
+                                - wait_info.send_epochtime,
+                            }
                         )
+                        self.reporter.record()
 
                 # This function only queues the message.  A send_message_thread instance will pick
                 # it up and send it.

--- a/python/device/device.py
+++ b/python/device/device.py
@@ -63,7 +63,6 @@ azure_monitor.add_logging_properties(
     pool_id=requested_service_pool,
 )
 event_logger = azure_monitor.get_event_logger()
-azure_monitor.log_all_warnings_and_exceptions_to_azure_monitor()
 azure_monitor.log_to_azure_monitor("thief")
 
 
@@ -1178,7 +1177,7 @@ class DeviceApp(app_base.AppBase):
 if __name__ == "__main__":
     try:
         if len(sys.argv) > 1:
-            run_reason =  " ".join(sys.argv[1:])
+            run_reason = " ".join(sys.argv[1:])
         DeviceApp().main()
     except BaseException as e:
         logger.critical("App shutdown exception: {}".format(str(e) or type(e)), exc_info=True)

--- a/python/service/service.py
+++ b/python/service/service.py
@@ -377,7 +377,10 @@ class ServiceApp(app_base.AppBase):
                     break
                 if service_ack.device_id not in service_acks:
                     service_acks[service_ack.device_id] = []
-                service_acks[service_ack.device_id].append(service_ack.service_ack_id)
+                # it's possible to get the same eventhub message twice, especially if we have to reconnect
+                # to refresh credentials. Don't send the same service ack twice.
+                if service_ack.service_ack_id not in service_acks[service_ack.device_id]:
+                    service_acks[service_ack.device_id].append(service_ack.service_ack_id)
 
             for device_id in service_acks:
 

--- a/python/service/service.py
+++ b/python/service/service.py
@@ -49,7 +49,6 @@ azure_monitor.add_logging_properties(
     pool_id=service_pool,
 )
 event_logger = azure_monitor.get_event_logger()
-azure_monitor.log_all_warnings_and_exceptions_to_azure_monitor()
 azure_monitor.log_to_azure_monitor("thief")
 
 ServiceAck = collections.namedtuple("ServiceAck", "device_id service_ack_id")


### PR DESCRIPTION
Python logging, as configured, would push all warnings and errors _twice_ to Azure Monitor.  Info and Debug would only go once.  This filters out the duplicate messages.