### PR TITLE
Generate new guids when restarting containers

### DIFF
--- a/python/containers/run-device.sh
+++ b/python/containers/run-device.sh
@@ -2,4 +2,5 @@
 # Licensed under the MIT license. See LICENSE file in the project root for
 # full license information.
 source /fetch-device-secrets.sh
+export THIEF_RUN_ID=$(uuidgen)
 python -u /device/device.py 2>&1 | tee /mnt/logs/dev-${THIEF_DEVICE_ID}-${THIEF_RUN_ID}.txt

--- a/python/containers/run-service.sh
+++ b/python/containers/run-service.sh
@@ -2,6 +2,7 @@
 # Licensed under the MIT license. See LICENSE file in the project root for
 # full license information.
 source /fetch-service-secrets.sh
+export THIEF_SERVICE_INSTANCE_ID=$(uuidgen)
 python -u /service/service.py 2>&1 | tee /mnt/logs/svc-${THIEF_SERVICE_POOL}-${THIEF_SERVICE_INSTANCE_ID}.txt
 echo "Python app is complete.  Exiting in 60 seconds"
 sleep 60

--- a/scripts/_parse_args
+++ b/scripts/_parse_args
@@ -45,16 +45,8 @@ while [ "$1" != "" ]; do
             export EXTRA_TAG=$1
             shift
             ;;
-        "--run_id")
-            export RUN_ID=$1
-            shift
-            ;;
         "--run_reason")
             export RUN_REASON=$1
-            shift
-            ;;
-        "--service_instance_id")
-            export SERVICE_INSTANCE_ID=$1
             shift
             ;;
         *)

--- a/scripts/run-container.sh
+++ b/scripts/run-container.sh
@@ -5,7 +5,7 @@ set -e
 script_dir=$(cd "$(dirname "$0")" && pwd)
 
 function usage {
-    echo "USAGE: ${0} [--platform platform] --langauge language_short_name --library library [--source library_source] --version library_version --pool service_pool [--device_id device_id] [--tag extra_tag] [--runid id] [--run_reason ] [--service_instance_id id]"
+    echo "USAGE: ${0} [--platform platform] --langauge language_short_name --library library [--source library_source] --version library_version --pool service_pool [--device_id device_id] [--tag extra_tag] [--run_reason ]"
     echo "  ex: ${0} --language py37 --library device --source pypi --version 2.3.0 --pool pool_1"
     exit 1
 }
@@ -35,13 +35,6 @@ case ${LIBRARY} in
             echo "ERROR: --device_id is required when library==device"
             usage
         fi
-        if [ "${SERVICE_INSTANCE_ID}" != "" ]; then
-            echo "ERROR: --service_instance_id is not valid when library==device"
-            usage
-        fi
-        if [ "${RUN_ID}" == "" ]; then
-            RUN_ID=$(uuidgen)
-        fi
         CONTAINER_NAME=${DEVICE_ID}-device
         ;;
     service)
@@ -49,16 +42,9 @@ case ${LIBRARY} in
             echo "ERROR: --device_id must not used when library==service"
             usage
         fi
-        if [ "${RUN_ID}" != "" ]; then
-            echo "ERROR: --run_id is not valid when library==service"
-            usage
-        fi
         if [ "${RUN_REASON}" != "" ]; then
             echo "ERROR: --run_reason is not valid when library==service"
             usage
-        fi
-        if [ "${SERVICE_INSTANCE_ID}" == "" ]; then
-            SERVICE_INSTANCE_ID=$(uuidgen)
         fi
         CONTAINER_NAME=${SERVICE_POOL}-service
         ;;
@@ -81,7 +67,6 @@ case ${LIBRARY} in
             THIEF_DEVICE_ID=${DEVICE_ID} \
             THIEF_REQUESTED_SERVICE_POOL=${SERVICE_POOL} \
             THIEF_KEYVAULT_NAME=${THIEF_KEYVAULT_NAME} \
-            THIEF_RUN_ID=${RUN_ID} \
             THIEF_RUN_REASON=\"${RUN_REASON}\" \
         )
         ;;
@@ -89,7 +74,6 @@ case ${LIBRARY} in
         ENV=(\
             THIEF_SERVICE_POOL=${SERVICE_POOL} \
             THIEF_KEYVAULT_NAME=${THIEF_KEYVAULT_NAME} \
-            THIEF_SERVICE_INSTANCE_ID=${SERVICE_INSTANCE_ID} \
         )
         ;;
 esac

--- a/scripts/run-container.sh
+++ b/scripts/run-container.sh
@@ -89,7 +89,7 @@ az container create \
     --environment-variables "${ENV[@]}" \
     --registry-username ${THIEF_CONTAINER_REGISTRY_USER} \
     --registry-password ${THIEF_CONTAINER_REGISTRY_PASSWORD} \
-    --restart-policy Never \
+    --restart-policy Always \
     --azure-file-volume-account-name ${THIEF_SHARED_LOG_STORAGE_ACCOUNT_NAME} \
     --azure-file-volume-account-key ${THIEF_SHARED_LOG_STORAGE_ACCOUNT_KEY} \
     --azure-file-volume-share-name ${THIEF_SHARED_LOG_STORAGE_SHARE_NAME} \


### PR DESCRIPTION
If containers are configured to restart when crashed, they need to generate new run_id and service_instance_id values every time they start.  In order to do this, I needed to move the guid generation out of the "launch" scripts and into the "run" scripts.