### PR TITLE
Increase stress pressure and update metrics/settings

### DIFF
--- a/codegen/constants.yaml
+++ b/codegen/constants.yaml
@@ -27,6 +27,24 @@ groups:
         - name: DESIRED 
           value: "desired"
     subgroups:
+      - name: TestRunProgress
+        desc: "Test run progress"
+        values:
+          - name: RUN_START_UTC
+            value: "runStartUtc"
+            desc: "Start of the run in UTC time"
+          - name: LATEST_UPDATE_TIME_UTC
+            value: "latestUpdateTimeUtc"
+            desc: "Latest metric update in UTC time"
+          - name: ELAPSED_TIME
+            value: "elapsedTime"
+            desc: "Elapsed test time"
+          - name: RUN_STATE
+            value: "runState"
+            desc: "State of the run: Running, Failed, etc"
+          - name: EXIT_REASON
+            value: "exitReason"
+            desc: "Reason the text exited"
       - name: Telemetry
         values:
           - name: CMD 
@@ -196,24 +214,6 @@ groups:
     sendToAzureMonitor: True
     subgroups:
 
-      - desc: "Run Metrics"
-        values:
-          - name: RUN_START_UTC
-            value: "runStartUtc"
-            desc: "Start of the run in UTC time"
-          - name: LATEST_UPDATE_TIME_UTC
-            value: "latestUpdateTimeUtc"
-            desc: "Latest metric update in UTC time"
-          - name: ELAPSED_TIME
-            value: "elapsedTime"
-            desc: "Elapsed test time"
-          - name: RUN_STATE
-            value: "runState"
-            desc: "State of the run: Running, Failed, etc"
-          - name: EXIT_REASON
-            value: "exitReason"
-            desc: "Reason the text exited"
-
       - desc: "System Health metrics"
         values:
           - name: PROCESS_CPU_PERCENT 
@@ -221,26 +221,36 @@ groups:
             desc: "CPU use for the device app, as a percentage of all cores"
             type: float
             units: percentage
-          - name: PROCESS_WORKING_SET 
+          - name: PROCESS_WORKING_SET_BYTES
             value: "processWorkingSet"
             desc: "Working set for the device app, includes shared and private, read-only and writeable memory"
             type: int
             units: bytes
-          - name: PROCESS_BYTES_IN_ALL_HEAPS 
-            value: "processBytesInAllHeaps"
-            desc: "Size of all heaps for the device app, essentially 'all available memory'"
-            type: int
-            units: bytes
-          - name: PROCESS_PRIVATE_BYTES 
-            value: "processPrivateBytes"
-            desc: "Amount of private data used by the process"
-            type: int
-            units: bytes
-          - name: PROCESS_WORKING_SET_PRIVATE 
+          - name: PROCESS_WORKING_SET_PRIVATE_BYTES
             value: "processWorkingSetPrivate"
             desc: "Amount of private data used by the process"
             type: int
             units: bytes
+          - name: PROCESS_GARBAGE_COLLECTION_OBJECTS
+            value: "processGarbageCollectionObjects"
+            desc: "Number of active objects being managed by the garbage collector"
+            type: int
+            units: objects
+          - name: PROCESS_SDK_THREADS
+            value: "processSdkThreads"
+            desc: "number of threads being used by the current SDK"
+            type: int
+            units: threads
+          - name: TEST_APP_ACTIVE_RECEIVE_THREADS
+            value: "testAppActiveReceiveThreads"
+            desc: "number of active threads in the test app receive threadpool"
+            type: int
+            units: threads
+          - name: TEST_APP_ACTIVE_SEND_THREADS
+            value: "testAppActiveSendThreads"
+            desc: "number of active threads in the test app send threadpool"
+            type: int
+            units: threads
 
       - desc: "test app metrics"
         values:
@@ -270,11 +280,6 @@ groups:
 
       - desc: "Receive c2d metrics"
         values:
-          - name: RECEIVE_C2D_COUNT_SENT 
-            value: "receiveC2dCountSent"
-            desc: "Number of c2d messages sent"
-            type: int
-            units: messages
           - name: RECEIVE_C2D_COUNT_RECEIVED 
             value: "receiveC2dCountReceived"
             desc: "Number of c2d messages received"
@@ -351,21 +356,6 @@ groups:
             desc: "Number of milliseconds between queueing a telemetry message and actually sending it"
             type: float
             units: milliseconds
-          - name: LATENCY_SEND_MESSAGE_TO_SERVICE_ACK 
-            value: "latencySendMessageToServiceAckInSeconds"
-            desc: "Number of seconds between sending a telemetry message and receiving the verification from the service app"
-            type: float
-            units: milliseconds
-          - name: LATENCY_ADD_REPORTED_PROPERTY_TO_SERVICE_ACK 
-            value: "latencyAddReportedPropertyToServiceAckInSeconds"
-            desc: "Number of seconds between adding a reported property and receiving verification of the add from the service app"
-            type: float
-            units: seconds
-          - name: LATENCY_REMOVE_REPORTED_PROPERTY_TO_SERVICE_ACK 
-            value: "latencyRemoveReportedPropertyToServiceAckInSeconds"
-            desc: "Number of seconds between removing a reported property and receiving verification of the removal from the service app"
-            type: float
-            units: seconds
 
   - name: SystemProperties
     desc: "Properties for the system runnin the test"
@@ -413,6 +403,18 @@ groups:
       - name: OPERATION_TIMEOUT_ALLOWED_FAILURE_COUNT 
         value: "operationTimeoutAllowedFailureCount"
         desc: "How many timeouts are allowed before the test fails"
+      - name: MQTT_KEEP_ALIVE_INTERVAL
+        value: "mqttKeepAliveInterval"
+        desc: "interval (in seconds) for sending PINGREQ packets on quiet MQTT connections"
+      - name: SAS_TOKEN_RENEWAL_INTERVAL
+        value: "sasTokenRenewalInterval"
+        desc: "interval (in seconds) for renewing SAS tokens"
+      - name: MAX_TEST_SEND_THREADS
+        value: "maxTestSendThreads"
+        desc: "maximum number of send threads in the test app"
+      - name: MAX_TEST_RECEIVE_THREADS
+        value: "maxTestReceiveThreads"
+        desc: "maximum number of receive threads in the test app"
 
     subgroups:
       - desc: "pairing settings"

--- a/python/common/measurement.py
+++ b/python/common/measurement.py
@@ -1,10 +1,7 @@
 # Copyright (c) Microsoft. All rights reserved.
 # Licensed under the MIT license. See LICENSE file in the project root for
 # full license information.
-import statistics
 import threading
-import contextlib
-import time
 
 
 class ThreadSafeCounter(object):
@@ -35,63 +32,3 @@ class ThreadSafeCounter(object):
             value = self.value
             self.value = 0
             return value
-
-
-class ThreadSafeList(object):
-    def __init__(self):
-        self.lock = threading.Lock()
-        self.list = []
-
-    def append(self, value):
-        with self.lock:
-            self.list.append(value)
-
-    def clear(self):
-        with self.lock:
-            self.list.clear()
-
-    def get_average(self):
-        with self.lock:
-            return statistics.mean(self.list)
-
-    def extract_average(self):
-        with self.lock:
-            average = 0
-            if len(self.list):
-                average = statistics.mean(self.list)
-                self.list.clear()
-            return average
-
-    def extract_list(self):
-        with self.lock:
-            old_list = self.list
-            self.list = []
-            return old_list
-
-    def get_len(self):
-        with self.lock:
-            return len(self.list)
-
-
-class MeasureLatency(contextlib.AbstractContextManager):
-    def __init__(self, tracker=None):
-        self.start_time = None
-        self.end_time = None
-        self.tracker = tracker
-
-    def __enter__(self):
-        self.start_time = time.time()
-
-    def __exit__(self, *args):
-        self.end_time = time.time()
-        if self.tracker:
-            self.tracker.add_sample(self.get_latency())
-
-    def get_latency(self):
-        if self.start_time:
-            if self.end_time:
-                return self.end_time - self.start_time
-            else:
-                return time.time() - self.start_time
-        else:
-            return 0

--- a/python/common/system_health_telemetry.py
+++ b/python/common/system_health_telemetry.py
@@ -16,15 +16,11 @@ class SystemHealthTelemetry(object):
         return self.process.cpu_percent()
 
     @property
-    def process_working_set(self):
+    def process_working_set_bytes(self):
         return self.process.memory_info().rss
 
     @property
-    def process_bytes_in_all_heaps(self):
-        return self.process.memory_info().vms
-
-    @property
-    def process_private_bytes(self):
+    def process_working_set_private_bytes(self):
         if self.system == "Linux":
             memory_info = self.process.memory_info()
             # from /proc/{pid}/statm - equal to (VmRSS - (RssFile+RssShmem)) from /proc/{pid}/status
@@ -35,7 +31,3 @@ class SystemHealthTelemetry(object):
         else:
             # osx, aix, bsd -- undefined
             return 0
-
-    @property
-    def process_working_set_private(self):
-        return self.process_private_bytes

--- a/python/common/thief_constants.py
+++ b/python/common/thief_constants.py
@@ -23,6 +23,25 @@ class Fields(object):
     REPORTED = "reported"
     DESIRED = "desired"
 
+    # -----------------
+    # Test run progress
+    # -----------------
+
+    # Start of the run in UTC time
+    RUN_START_UTC = "runStartUtc"
+
+    # Latest metric update in UTC time
+    LATEST_UPDATE_TIME_UTC = "latestUpdateTimeUtc"
+
+    # Elapsed test time
+    ELAPSED_TIME = "elapsedTime"
+
+    # State of the run: Running, Failed, etc
+    RUN_STATE = "runState"
+
+    # Reason the text exited
+    EXIT_REASON = "exitReason"
+
     # ---------
     # Telemetry
     # ---------
@@ -179,25 +198,6 @@ class Metrics(object):
     Names of metrics which are pushed via reported properties, telemetry, and Azure Monitor
     """
 
-    # -----------
-    # Run Metrics
-    # -----------
-
-    # Start of the run in UTC time
-    RUN_START_UTC = "runStartUtc"
-
-    # Latest metric update in UTC time
-    LATEST_UPDATE_TIME_UTC = "latestUpdateTimeUtc"
-
-    # Elapsed test time
-    ELAPSED_TIME = "elapsedTime"
-
-    # State of the run: Running, Failed, etc
-    RUN_STATE = "runState"
-
-    # Reason the text exited
-    EXIT_REASON = "exitReason"
-
     # ---------------------
     # System Health metrics
     # ---------------------
@@ -206,16 +206,22 @@ class Metrics(object):
     PROCESS_CPU_PERCENT = "processCpuPercent"
 
     # Working set for the device app, includes shared and private, read-only and writeable memory
-    PROCESS_WORKING_SET = "processWorkingSet"
-
-    # Size of all heaps for the device app, essentially 'all available memory'
-    PROCESS_BYTES_IN_ALL_HEAPS = "processBytesInAllHeaps"
+    PROCESS_WORKING_SET_BYTES = "processWorkingSet"
 
     # Amount of private data used by the process
-    PROCESS_PRIVATE_BYTES = "processPrivateBytes"
+    PROCESS_WORKING_SET_PRIVATE_BYTES = "processWorkingSetPrivate"
 
-    # Amount of private data used by the process
-    PROCESS_WORKING_SET_PRIVATE = "processWorkingSetPrivate"
+    # Number of active objects being managed by the garbage collector
+    PROCESS_GARBAGE_COLLECTION_OBJECTS = "processGarbageCollectionObjects"
+
+    # number of threads being used by the current SDK
+    PROCESS_SDK_THREADS = "processSdkThreads"
+
+    # number of active threads in the test app receive threadpool
+    TEST_APP_ACTIVE_RECEIVE_THREADS = "testAppActiveReceiveThreads"
+
+    # number of active threads in the test app send threadpool
+    TEST_APP_ACTIVE_SEND_THREADS = "testAppActiveSendThreads"
 
     # ----------------
     # test app metrics
@@ -297,17 +303,6 @@ class Metrics(object):
     # Number of milliseconds between queueing a telemetry message and actually sending it
     LATENCY_QUEUE_MESSAGE_TO_SEND = "latencyQueueMessageToSendInMilliseconds"
 
-    # Number of seconds between sending a telemetry message and receiving the verification from the service app
-    LATENCY_SEND_MESSAGE_TO_SERVICE_ACK = "latencySendMessageToServiceAckInSeconds"
-
-    # Number of seconds between adding a reported property and receiving verification of the add from the service app
-    LATENCY_ADD_REPORTED_PROPERTY_TO_SERVICE_ACK = "latencyAddReportedPropertyToServiceAckInSeconds"
-
-    # Number of seconds between removing a reported property and receiving verification of the removal from the service app
-    LATENCY_REMOVE_REPORTED_PROPERTY_TO_SERVICE_ACK = (
-        "latencyRemoveReportedPropertyToServiceAckInSeconds"
-    )
-
 
 class SystemProperties(object):
     """
@@ -358,6 +353,18 @@ class Settings(object):
 
     # How many timeouts are allowed before the test fails
     OPERATION_TIMEOUT_ALLOWED_FAILURE_COUNT = "operationTimeoutAllowedFailureCount"
+
+    # interval (in seconds) for sending PINGREQ packets on quiet MQTT connections
+    MQTT_KEEP_ALIVE_INTERVAL = "mqttKeepAliveInterval"
+
+    # interval (in seconds) for renewing SAS tokens
+    SAS_TOKEN_RENEWAL_INTERVAL = "sasTokenRenewalInterval"
+
+    # maximum number of send threads in the test app
+    MAX_TEST_SEND_THREADS = "maxTestSendThreads"
+
+    # maximum number of receive threads in the test app
+    MAX_TEST_RECEIVE_THREADS = "maxTestReceiveThreads"
 
     # ----------------
     # pairing settings

--- a/python/device/device.py
+++ b/python/device/device.py
@@ -17,6 +17,7 @@ from executor import BetterThreadPoolExecutor, reset_watchdog, dump_active_stack
 import dps
 import queue
 import faulthandler
+import gc
 from azure.iot.device import Message, MethodResponse
 import azure.iot.device.constant
 from measurement import ThreadSafeCounter
@@ -141,14 +142,18 @@ Object we use internally to keep track of how the entire test is configured.
 Currently hardcoded. Later, this will come from desired properties.
 """
 device_run_config = {
-    Settings.MAX_RUN_DURATION_IN_SECONDS: 2 * 60,
+    Settings.MAX_RUN_DURATION_IN_SECONDS: 1 * 60 * 60,
     Settings.ALLOWED_EXCEPTION_COUNT: 10,
     Settings.INTER_TEST_DELAY_INTERVAL_IN_SECONDS: 1,
     Settings.OPERATION_TIMEOUT_IN_SECONDS: 60,
-    Settings.OPERATION_TIMEOUT_ALLOWED_FAILURE_COUNT: 1000,
+    Settings.OPERATION_TIMEOUT_ALLOWED_FAILURE_COUNT: 10,
     Settings.PAIRING_REQUEST_TIMEOUT_INTERVAL_IN_SECONDS: 900,
     Settings.PAIRING_REQUEST_SEND_INTERVAL_IN_SECONDS: 30,
-    Settings.SEND_MESSAGE_OPERATIONS_PER_SECOND: 1,
+    Settings.SEND_MESSAGE_OPERATIONS_PER_SECOND: 10,
+    Settings.MQTT_KEEP_ALIVE_INTERVAL: 20,
+    Settings.SAS_TOKEN_RENEWAL_INTERVAL: 600,
+    Settings.MAX_TEST_SEND_THREADS: 128,
+    Settings.MAX_TEST_RECEIVE_THREADS: 10,
 }
 
 
@@ -161,13 +166,18 @@ class DeviceApp(object):
         global device_run_config
         super(DeviceApp, self).__init__()
 
-        self.executor = BetterThreadPoolExecutor(max_workers=128)
+        self.config = device_run_config
+        self.outgoing_executor = BetterThreadPoolExecutor(
+            max_workers=self.config[Settings.MAX_TEST_SEND_THREADS]
+        )
+        self.incoming_executor = BetterThreadPoolExecutor(
+            max_workers=self.config[Settings.MAX_TEST_RECEIVE_THREADS]
+        )
         self.done = threading.Event()
         self.client = None
         self.hub = None
         self.device_id = None
         self.metrics = DeviceRunMetrics()
-        self.config = device_run_config
         self.service_instance_id = None
         self.system_health_telemetry = SystemHealthTelemetry()
         # for service_acks
@@ -192,22 +202,34 @@ class DeviceApp(object):
             "percentage",
         )
         self.reporter.add_integer_measurement(
-            Metrics.PROCESS_WORKING_SET,
+            Metrics.PROCESS_WORKING_SET_BYTES,
             "Working set for the device app, includes shared and private, read-only and writeable memory",
             "bytes",
         )
         self.reporter.add_integer_measurement(
-            Metrics.PROCESS_BYTES_IN_ALL_HEAPS,
-            "Size of all heaps for the device app, essentially 'all available memory'",
-            "bytes",
-        )
-        self.reporter.add_integer_measurement(
-            Metrics.PROCESS_PRIVATE_BYTES, "Amount of private data used by the process", "bytes",
-        )
-        self.reporter.add_integer_measurement(
-            Metrics.PROCESS_WORKING_SET_PRIVATE,
+            Metrics.PROCESS_WORKING_SET_PRIVATE_BYTES,
             "Amount of private data used by the process",
             "bytes",
+        )
+        self.reporter.add_integer_measurement(
+            Metrics.PROCESS_GARBAGE_COLLECTION_OBJECTS,
+            "Number of active objects being managed by the garbage collector",
+            "objects",
+        )
+        self.reporter.add_integer_measurement(
+            Metrics.PROCESS_SDK_THREADS,
+            "number of threads being used by the current SDK",
+            "threads",
+        )
+        self.reporter.add_integer_measurement(
+            Metrics.TEST_APP_ACTIVE_RECEIVE_THREADS,
+            "number of active threads in the test app receive threadpool",
+            "threads",
+        )
+        self.reporter.add_integer_measurement(
+            Metrics.TEST_APP_ACTIVE_SEND_THREADS,
+            "number of active threads in the test app send threadpool",
+            "threads",
         )
 
         # ----------------
@@ -317,21 +339,6 @@ class DeviceApp(object):
             "Number of milliseconds between queueing a telemetry message and actually sending it",
             "milliseconds",
         )
-        self.reporter.add_float_measurement(
-            Metrics.LATENCY_SEND_MESSAGE_TO_SERVICE_ACK,
-            "Number of seconds between sending a telemetry message and receiving the verification from the service app",
-            "milliseconds",
-        )
-        self.reporter.add_float_measurement(
-            Metrics.LATENCY_ADD_REPORTED_PROPERTY_TO_SERVICE_ACK,
-            "Number of seconds between adding a reported property and receiving verification of the add from the service app",
-            "seconds",
-        )
-        self.reporter.add_float_measurement(
-            Metrics.LATENCY_REMOVE_REPORTED_PROPERTY_TO_SERVICE_ACK,
-            "Number of seconds between removing a reported property and receiving verification of the removal from the service app",
-            "seconds",
-        )
 
     def get_session_metrics(self):
         """
@@ -341,11 +348,11 @@ class DeviceApp(object):
         elapsed_time = now - self.metrics.run_start_utc
 
         props = {
-            Metrics.RUN_START_UTC: self.metrics.run_start_utc.isoformat(),
-            Metrics.LATEST_UPDATE_TIME_UTC: now.isoformat(),
-            Metrics.ELAPSED_TIME: str(elapsed_time),
-            Metrics.RUN_STATE: str(self.metrics.run_state),
-            Metrics.EXIT_REASON: self.metrics.exit_reason,
+            Fields.RUN_START_UTC: self.metrics.run_start_utc.isoformat(),
+            Fields.LATEST_UPDATE_TIME_UTC: now.isoformat(),
+            Fields.ELAPSED_TIME: str(elapsed_time),
+            Fields.RUN_STATE: str(self.metrics.run_state),
+            Fields.EXIT_REASON: self.metrics.exit_reason,
         }
         return props
 
@@ -427,10 +434,16 @@ class DeviceApp(object):
     def get_system_health_telemetry(self):
         props = {
             Metrics.PROCESS_CPU_PERCENT: self.system_health_telemetry.process_cpu_percent,
-            Metrics.PROCESS_WORKING_SET: self.system_health_telemetry.process_working_set,
-            Metrics.PROCESS_BYTES_IN_ALL_HEAPS: self.system_health_telemetry.process_bytes_in_all_heaps,
-            Metrics.PROCESS_PRIVATE_BYTES: self.system_health_telemetry.process_private_bytes,
-            Metrics.PROCESS_WORKING_SET_PRIVATE: self.system_health_telemetry.process_working_set_private,
+            Metrics.PROCESS_WORKING_SET_BYTES: self.system_health_telemetry.process_working_set_bytes,
+            Metrics.PROCESS_WORKING_SET_PRIVATE_BYTES: self.system_health_telemetry.process_working_set_private_bytes,
+            Metrics.PROCESS_GARBAGE_COLLECTION_OBJECTS: len(gc.get_objects()),
+            Metrics.PROCESS_SDK_THREADS: threading.active_count()
+            - len(self.outgoing_executor.all_threads)
+            - len(self.incoming_executor.all_threads),
+            Metrics.TEST_APP_ACTIVE_RECEIVE_THREADS: len(
+                list(self.incoming_executor.active_threads)
+            ),
+            Metrics.TEST_APP_ACTIVE_SEND_THREADS: len(list(self.outgoing_executor.active_threads)),
         }
         return props
 
@@ -589,10 +602,7 @@ class DeviceApp(object):
 
                 with self.reporter_lock:
                     self.reporter.set_metrics_from_dict(
-                        {
-                            Metrics.LATENCY_QUEUE_MESSAGE_TO_SEND: (send_time - queue_time) * 1000,
-                            Metrics.LATENCY_SEND_MESSAGE_TO_SERVICE_ACK: time.time() - send_time,
-                        }
+                        {Metrics.LATENCY_QUEUE_MESSAGE_TO_SEND: (send_time - queue_time) * 1000}
                     )
                     self.reporter.record()
             else:
@@ -601,7 +611,7 @@ class DeviceApp(object):
 
         while not self.done.isSet():
             reset_watchdog()
-            self.executor.submit(send_message)
+            self.outgoing_executor.submit(send_message)
             # sleep until we need to send again
             self.done.wait(1 / self.config[Settings.SEND_MESSAGE_OPERATIONS_PER_SECOND])
 
@@ -636,7 +646,7 @@ class DeviceApp(object):
                 Commands.METHOD_RESPONSE,
                 Commands.C2D_RESPONSE,
             ]:
-                self.executor.submit(self.handle_service_ack_response, msg)
+                self.incoming_executor.submit(self.handle_service_ack_response, msg)
 
             else:
                 logger.warning("Unknown command received: {}".format(obj))
@@ -690,18 +700,7 @@ class DeviceApp(object):
         while not self.done.isSet():
             for (function, args, kwargs) in tests:
                 reset_watchdog()
-
-                try:
-                    function(*args, **kwargs)
-                except ThiefFatalException:
-                    raise
-                except Exception as e:
-                    logger.error(
-                        "Test function {} raised {}".format(
-                            function.__name__, str(e) or type(e), exc_info=True
-                        )
-                    )
-                    self.metrics.exception_count.increment()
+                self.outgoing_executor.submit(function, *args, **kwargs)
 
                 time.sleep(self.config[Settings.INTER_TEST_DELAY_INTERVAL_IN_SECONDS])
                 if self.done.isSet():
@@ -720,14 +719,14 @@ class DeviceApp(object):
 
         # Get metrics.  We report them to Azure monitor and also push them as part of the twin
         metrics = {
-            Fields.SESSION_METRICS: self.get_session_metrics(),
             Fields.TEST_METRICS: self.get_test_metrics(),
             Fields.SYSTEM_HEALTH_METRICS: self.get_system_health_telemetry(),
         }
         self.send_metrics_to_azure_monitor(metrics)
 
-        # systemHealthMetrics don't go into reported properties
-        del metrics[Fields.SYSTEM_HEALTH_METRICS]
+        # session metrics goes into reported propertes, but not azure monitor
+        # They're either never-changing (like start time) or redundant (like elapsed time)
+        metrics[Fields.SESSION_METRICS] = self.get_session_metrics()
 
         def make_reported_prop(property_name, val):
             return {
@@ -748,7 +747,6 @@ class DeviceApp(object):
         }
 
         logger.info("Adding test property {}".format(prop_name))
-        start_time = time.time()
         props = make_reported_prop(prop_name, prop_value)
         props[Fields.THIEF].update(metrics)
         self.client.patch_twin_reported_properties(props)
@@ -756,25 +754,16 @@ class DeviceApp(object):
         if add_operation.event.wait(timeout=self.config[Settings.OPERATION_TIMEOUT_IN_SECONDS]):
             logger.info("Add of reported property {} verified by service".format(prop_name))
             self.metrics.reported_properties_count_added.increment()
-            self.reporter.set_metric(
-                Metrics.LATENCY_ADD_REPORTED_PROPERTY_TO_SERVICE_ACK, time.time() - start_time
-            )
-            self.reporter.record()
         else:
             logger.info("Add of reported property {} verification timeout".format(prop_name))
             self.metrics.reported_properties_count_timed_out.increment()
 
         logger.info("Removing test property {}".format(prop_name))
-        start_time = time.time()
         self.client.patch_twin_reported_properties(make_reported_prop(prop_name, None))
 
         if remove_operation.event.wait(timeout=self.config[Settings.OPERATION_TIMEOUT_IN_SECONDS]):
             logger.info("Remove of reported property {} verified by service".format(prop_name))
             self.metrics.reported_properties_count_removed.increment()
-            self.reporter.set_metric(
-                Metrics.LATENCY_REMOVE_REPORTED_PROPERTY_TO_SERVICE_ACK, time.time() - start_time,
-            )
-            self.reporter.record()
         else:
             logger.info("Remove of reported property {} verification timeout".format(prop_name))
             self.metrics.reported_properties_count_timed_out.increment()
@@ -874,7 +863,7 @@ class DeviceApp(object):
                     MethodResponse.create_from_method_request(method_request, 500)
                 )
 
-        self.executor.submit(handle)
+        self.incoming_executor.submit(handle)
 
     def make_random_payload(self):
         return {
@@ -1000,6 +989,8 @@ class DeviceApp(object):
             registration_id=registration_id,
             id_scope=id_scope,
             group_symmetric_key=group_symmetric_key,
+            keep_alive=self.config[Settings.MQTT_KEEP_ALIVE_INTERVAL],
+            sastoken_ttl=self.config[Settings.SAS_TOKEN_RENEWAL_INTERVAL],
         )
         hub_host_name = self.hub[: self.hub.find(".")]  # keep everything before the first dot
         azure_monitor.add_logging_properties(hub=hub_host_name, device_id=self.device_id)
@@ -1020,8 +1011,8 @@ class DeviceApp(object):
         self.pair_with_service()
 
         # Start testing threads
-        self.executor.submit(self.test_send_message_thread, critical=True)
-        self.executor.submit(self.operation_test_thread, critical=True)
+        self.outgoing_executor.submit(self.test_send_message_thread, critical=True)
+        self.outgoing_executor.submit(self.operation_test_thread, critical=True)
 
         self.metrics.exit_reason = ""
         start_time = time.time()
@@ -1029,8 +1020,9 @@ class DeviceApp(object):
         try:
             while time.time() < planned_end_time:
                 # TODO: limit sleep length to check failure counts more often
-                self.executor.wait_for_thread_death_event(planned_end_time - time.time())
-                self.executor.check_watchdogs()
+                self.outgoing_executor.wait_for_thread_death_event(planned_end_time - time.time())
+                self.outgoing_executor.check_watchdogs()
+                self.incoming_executor.check_watchdogs()
 
                 non_fatal_errors = 0
                 fatal_error = None
@@ -1043,12 +1035,14 @@ class DeviceApp(object):
                     else:
                         non_fatal_errors += 1
 
-                self.executor.check_for_failures(count_failure)
+                self.outgoing_executor.check_for_failures(count_failure)
+                self.incoming_executor.check_for_failures(count_failure)
                 if non_fatal_errors:
                     logger.info("Adding {} failures to count".format(non_fatal_errors))
                     self.metrics.exception_count.add(non_fatal_errors)
                 if fatal_error:
                     raise (fatal_error)
+            self.metrics.run_state = RunStates.COMPLETE
         except KeyboardInterrupt:
             self.metrics.run_state = RunStates.INTERRUPTED
             self.metrics.exit_reason = "KeyboardInterrupt"
@@ -1056,18 +1050,22 @@ class DeviceApp(object):
         except BaseException as e:
             self.metrics.run_state = RunStates.FAILED
             self.metrics.exit_reason = str(e) or type(e)
+            logger.error("Run failed: {}".format(self.metrics.exit_reason), exc_info=True)
             raise
         finally:
             logger.info("-------------------------------------------------------------")
             logger.info("Setting done flag: {}".format(self.metrics.exit_reason))
             logger.info("-------------------------------------------------------------")
             self.done.set()
-            done, not_done = self.executor.wait(
-                timeout=2 * self.config[Settings.OPERATION_TIMEOUT_IN_SECONDS]
-            )
-            if not_done:
-                logger.error("{} threads not stopped after ending run".format(len(not_done)))
-                dump_active_stacks(self.executor)
+            active_threads = 0
+            for executor in [self.outgoing_executor, self.incoming_executor]:
+                done, not_done = executor.wait(
+                    timeout=2 * self.config[Settings.OPERATION_TIMEOUT_IN_SECONDS]
+                )
+                active_threads += len(not_done)
+            if active_threads:
+                logger.error("{} threads not stopped after ending run".format(active_threads))
+                dump_active_stacks(logger.info)
 
             logger.info("Exiting main at {}".format(datetime.datetime.utcnow()))
             event_logger.info(
@@ -1081,6 +1079,7 @@ class DeviceApp(object):
                 Fields.THIEF: {
                     Fields.SESSION_METRICS: self.get_session_metrics(),
                     Fields.TEST_METRICS: self.get_test_metrics(),
+                    Fields.SYSTEM_HEALTH_METRICS: self.get_system_health_telemetry(),
                 }
             }
             logger.info("Results: {}".format(pprint.pformat(props)))

--- a/python/device/device.py
+++ b/python/device/device.py
@@ -142,7 +142,7 @@ Object we use internally to keep track of how the entire test is configured.
 Currently hardcoded. Later, this will come from desired properties.
 """
 device_run_config = {
-    Settings.MAX_RUN_DURATION_IN_SECONDS: 1 * 60 * 60,
+    Settings.MAX_RUN_DURATION_IN_SECONDS: 2 * 60,
     Settings.ALLOWED_EXCEPTION_COUNT: 10,
     Settings.INTER_TEST_DELAY_INTERVAL_IN_SECONDS: 1,
     Settings.OPERATION_TIMEOUT_IN_SECONDS: 60,

--- a/python/device/dps.py
+++ b/python/device/dps.py
@@ -23,7 +23,7 @@ def _derive_device_key(registration_id, group_symmetric_key):
 
 
 def create_device_client_using_dps_group_key(
-    provisioning_host, registration_id, id_scope, group_symmetric_key
+    provisioning_host, registration_id, id_scope, group_symmetric_key, **kwargs
 ):
     device_key = _derive_device_key(registration_id, group_symmetric_key)
     provisioning_client = ProvisioningDeviceClient.create_from_symmetric_key(
@@ -41,6 +41,6 @@ def create_device_client_using_dps_group_key(
     device_id = registration_result.registration_state.device_id
 
     client = IoTHubDeviceClient.create_from_symmetric_key(
-        symmetric_key=device_key, hostname=hostname, device_id=device_id,
+        symmetric_key=device_key, hostname=hostname, device_id=device_id, **kwargs,
     )
     return client, hostname, device_id


### PR DESCRIPTION
Stress updates:
* Increased default nubmer of operations per second and overlapped more operations.
* Split python thread pools into send & receive.  Under stress, there used to be a simple deadlock where all threads would be waiting for a response, so no responses could be handled.
* Added configuration options for token interval, keepalive, and thread counts.

Metrics/Settings:
* Limited memory metrics to working set and private working set.
* Added metrics for gc object count and active thread count.  These won't be used by all languages but are useful anyway.
* Removed latency metrics.  Because these measure round-trip and responses are batched, these are all but useless as-is.
